### PR TITLE
Allow YAML quotes around action names

### DIFF
--- a/src/gha_update/_core.py
+++ b/src/gha_update/_core.py
@@ -69,7 +69,7 @@ def read_workflows() -> dict[Path, set[str]]:
 
 
 def find_name_in_line(line: str) -> str | None:
-    uses = line.partition(" uses:")[2].strip()
+    uses = line.partition(" uses:")[2].strip(' "')
 
     # ignore other lines, and local and docker actions
     if not uses or uses.startswith("./") or uses.startswith("docker://"):


### PR DESCRIPTION
I tried applying this on trustme, but this failed on this line that is using quotes: https://github.com/python-trio/trustme/blob/7b7f43596a039ef27dcf3e26e45ed138e482acfc/.github/workflows/ci.yml#L29

Actually, this does not fully fix the problem, as I end up with this diff, with a missing quote at the end:

```
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@v4.4.0
```

And this is not the only tools that require unquoted actions, see https://github.com/urllib3/urllib3/pull/3121 for reference. So maybe throwing an error here would be best instead.