### PR TITLE
handle non-standard gh response codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- Follow redirects for moved projects. {issue}`1`
+- Read `GITHUB_TOKEN` to make authenticated requests, and advise setting it if
+  a rate limit is reached. {issue}`7`
+
 ## Version 0.1.0
 
 Released 2024-08-23


### PR DESCRIPTION
This PR would (at least in my testing) fix two issues relating to non-standard response codes
1) Allows the user to set the GITHUB_TOKEN env variable, which is passed in the headers, resolves #7
2) Makes another request if github indicates a redirect, resolves #10 