### PR TITLE
Use only the default config when no config file exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Unreleased
 - Follow redirects for moved projects. {issue}`1`
 - Read `GITHUB_TOKEN` to make authenticated requests, and advise setting it if
   a rate limit is reached. {issue}`7`
+- Use default config if the config file does not exist. {issue}`14`
 
 ## Version 0.1.0
 

--- a/src/gha_update/_cli.py
+++ b/src/gha_update/_cli.py
@@ -11,7 +11,7 @@ from ._core import update_workflows
 @click.option(
     "config_path",
     "--config",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    type=click.Path(exists=False, dir_okay=False, path_type=Path),
     default=Path("pyproject.toml"),
     help="TOML file containing a [tool.gha-update] section.",
 )

--- a/src/gha_update/_core.py
+++ b/src/gha_update/_core.py
@@ -26,8 +26,14 @@ default_config: Config = {
 
 
 def load_config_path(path: os.PathLike[str] | str) -> Config:
-    data = tomllib.loads(Path(path).read_text("utf-8"))
-    config = data.get("tool", {}).get("gha-update", {})
+    path = Path(path)
+
+    if path.exists():
+        data = tomllib.loads(path.read_text("utf-8"))
+        config = data.get("tool", {}).get("gha-update", {})
+    else:
+        config = {}
+
     return {**default_config, **config}  # pyright: ignore
 
 


### PR DESCRIPTION
This enables gha updates in projects without pyproject.