### PR TITLE
remove slsa provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      hash: ${{ steps.hash.outputs.hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
@@ -18,24 +16,11 @@ jobs:
           python-version-file: pyproject.toml
       - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
       - run: uv build
-      - name: generate hash
-        id: hash
-        run: cd dist && echo "hash=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           path: ./dist
-  provenance:
-    needs: [build]
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects: ${{ needs.build.outputs.hash }}
   create-release:
-    needs: [provenance]
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -44,12 +29,11 @@ jobs:
       - name: create release
         run: >
           gh release create --draft --repo ${{ github.repository }}
-          ${{ github.ref_name }}
-          *.intoto.jsonl/* artifact/*
+          ${{ github.ref_name }} artifact/*
         env:
           GH_TOKEN: ${{ github.token }}
   publish-pypi:
-    needs: [provenance]
+    needs: [build]
     environment:
       name: publish
       url: https://pypi.org/project/gha-update/${{ github.ref_name }}


### PR DESCRIPTION
PyPI and trusted publishing has built-in attestation support now.