### PR TITLE
support github enterprise server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Unreleased
   `action.yaml`/`.yml` file in folders in `.github/actions` or at the root.
   {issue}`6`
 - Don't fail if `workflows` folder is missing.
+- Add `ghes-host` config to access a GitHub Enterprise Server. {issue}`16`
 
 ## Version 0.1.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,8 @@ TOML file. The following options are available:
     than the commit hash for that tag. For example, the
     `slsa-framework/slsa-github-generator` action can't work correctly when
     pinned as a hash.
+-   `ghes-host`: The hostname when using GitHub Enterprise Server.
+
 
 Making requests to GitHub's API is rate limited, with a higher limit if an
 access token is used. If the `GITHUB_TOKEN` environment variable is set, it will


### PR DESCRIPTION
Add `ghes-host` config. When set, make API requests to `https://host/api/v3/` instead of `https://api.github.com`.

closes #16 