### PR TITLE
handle pagination in tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Unreleased
   {issue}`6`
 - Don't fail if `workflows` folder is missing.
 - Add `ghes-host` config to access a GitHub Enterprise Server. {issue}`16`
+- Handle pagination when fetching tags. Show an error if no version tags were
+  found. {issue}`15`
 
 ## Version 0.1.0
 


### PR DESCRIPTION
I previously assumed that tags were returned newest first, so we only needed the first page of results. However, fetching them for https://github.com/crate-ci/typos/releases seems to return the tags in some other order. Handle pagination to collect all the tags.

Additionally, show an error if not version tags could be parsed. This could happen because the repo has no tags, or the tags are in some format we don't understand/can't sort.

closes #15 