### PR TITLE
Support quoted actions

### DIFF
--- a/src/gha_update/_core.py
+++ b/src/gha_update/_core.py
@@ -212,7 +212,6 @@ def write_workflows(
                     line = f"{left}@{tag}{maybe_quote}"
                 else:
                     line = f"{left}@{commit}{maybe_quote} # {tag}"
-                print(line)
 
             out.append(line)
 

--- a/src/gha_update/_core.py
+++ b/src/gha_update/_core.py
@@ -104,10 +104,10 @@ def read_workflows() -> dict[Path, set[str]]:
 
 
 def find_name_in_line(line: str) -> str | None:
-    uses = line.partition(" uses:")[2].strip()
+    uses = line.partition(" uses:")[2].strip("'\" \t\n\r\f\v")
 
     # ignore other lines, and local and docker actions
-    if not uses or uses.startswith("./") or uses.startswith("docker://"):
+    if not uses or uses.startswith(("./")) or uses.startswith("docker://"):
         return None
 
     parts = uses.partition("@")[0].split("/")
@@ -204,11 +204,16 @@ def write_workflows(
             if (name := find_name_in_line(line)) is not None and name in versions:
                 left, _, right = line.partition("@")
                 tag, commit = versions[name]
-
-                if name in config["tag-only"]:
-                    line = f"{left}@{tag}"
+                print(left)
+                if match := re.search(r"uses:\s*(['\"])?", line):
+                    maybe_quote = match.group(1) or ""
                 else:
-                    line = f"{left}@{commit} # {tag}"
+                    maybe_quote = ""
+                if name in config["tag-only"]:
+                    line = f"{left}@{tag}{maybe_quote}"
+                else:
+                    line = f"{left}@{commit}{maybe_quote} # {tag}"
+                print(line)
 
             out.append(line)
 

--- a/src/gha_update/_core.py
+++ b/src/gha_update/_core.py
@@ -107,7 +107,7 @@ def find_name_in_line(line: str) -> str | None:
     uses = line.partition(" uses:")[2].strip("'\" \t\n\r\f\v")
 
     # ignore other lines, and local and docker actions
-    if not uses or uses.startswith(("./")) or uses.startswith("docker://"):
+    if not uses or uses.startswith(("./", "docker://")):
         return None
 
     parts = uses.partition("@")[0].split("/")
@@ -204,7 +204,6 @@ def write_workflows(
             if (name := find_name_in_line(line)) is not None and name in versions:
                 left, _, right = line.partition("@")
                 tag, commit = versions[name]
-                print(left)
                 if match := re.search(r"uses:\s*(['\"])?", line):
                     maybe_quote = match.group(1) or ""
                 else:


### PR DESCRIPTION
Noticed `gha-update` chokes on this type of input (note quoted `uses` value):

```yaml
      - id: 'auth'
        name: 'Authenticate to Google Cloud'
        uses: 'google-github-actions/auth@v0'
        with:
          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
```
