### PR TITLE
Bump pyright for 3.14's templatelib

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -613,15 +613,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.403"
+version = "1.1.408"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Before:

```console
❯ uv run --locked tox run -e typing
Uninstalled 1 package in 395ms
Installed 1 package in 125ms
typing: uv-sync> uv sync --locked --python-preference system --no-default-groups --no-editable --reinstall-package gha-update --group typing -p /Users/hugo/github/gha-update/.venv/bin/python
typing: commands[0]> mypy
Success: no issues found in 4 source files
typing: commands[1]> pyright
WARNING: there is a new pyright version available (v1.1.403 -> v1.1.408).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/string/templatelib.py
  /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/string/templatelib.py:3:5 - error: Template string literals (t-strings) require Python 3.14 or newer
  /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/string/templatelib.py:5:24 - error: Cannot access attribute "interpolations" for class "str"
    Attribute "interpolations" is unknown (reportAttributeAccessIssue)
2 errors, 0 warnings, 0 informations
typing: exit 1 (1.00 seconds) /Users/hugo/github/gha-update> pyright pid=45687
  typing: FAIL code 1 (1.91=setup[0.73]+cmd[0.19,1.00] seconds)
  evaluation failed :( (1.98 seconds)
```

Fix:

```console
❯ uv lock --upgrade-package pyright
Resolved 71 packages in 87ms
```

After:

```console
❯ uv run --locked tox run -e typing
Uninstalled 1 package in 311ms
Installed 1 package in 87ms
typing: uv-sync> uv sync --locked --python-preference system --no-default-groups --no-editable --reinstall-package gha-update --group typing -p /Users/hugo/github/gha-update/.venv/bin/python
typing: commands[0]> mypy
Success: no issues found in 4 source files
typing: commands[1]> pyright
0 errors, 0 warnings, 0 informations
  typing: OK (1.58=setup[0.55]+cmd[0.13,0.90] seconds)
  congratulations :) (1.62 seconds)
```
